### PR TITLE
feat: sync form changes across collaborators

### DIFF
--- a/src/components/bpm/FormCollaborationPanel.vue
+++ b/src/components/bpm/FormCollaborationPanel.vue
@@ -29,7 +29,12 @@
     <!-- 用户列表 -->
     <div class="user-list-container" v-show="!isCollapsed">
       <transition-group name="user-list" tag="ul" class="user-list" v-if="onlineUsers.length">
-        <li v-for="user in onlineUsers" :key="user.id" class="user-item" :class="{'highlighted': user.id % 2 === 0}">
+        <li
+          v-for="user in onlineUsers"
+          :key="user.id"
+          class="user-item"
+          :class="{ highlighted: user.id % 2 === 0 }"
+        >
           <div class="user-avatar">
             <el-avatar :size="36" v-if="user.avatar" :src="user.avatar" />
             <el-avatar :size="36" v-else>{{ user.nickname?.substring(0, 1) }}</el-avatar>
@@ -38,7 +43,9 @@
           <div class="user-info">
             <span class="user-name">{{ user.nickname }}</span>
           </div>
-          <div class="user-status">在线</div>
+          <div class="user-status">
+            {{ props.editingUsers.has(user.id) ? '编辑中' : '在线' }}
+          </div>
         </li>
       </transition-group>
       <div v-else class="empty-state">
@@ -56,6 +63,7 @@ import { Close, Connection, UserFilled, ArrowUp, ArrowDown } from '@element-plus
 interface Props {
   processUsers: any[]
   confirmedOnlineUsers: Set<number>
+  editingUsers: Set<number>
 }
 
 const props = defineProps<Props>()

--- a/src/hooks/web/useWebSocketMessage.ts
+++ b/src/hooks/web/useWebSocketMessage.ts
@@ -410,6 +410,26 @@ export const useWebSocketMessage = () => {
     }
   }
 
+  /**
+   * 向多个用户发送消息
+   * @param userIds 目标用户ID数组
+   * @param message 消息内容
+   * @param priority 消息优先级
+   * @param messageId 自定义消息ID
+   */
+  const sendToUsers = async (
+    userIds: number[],
+    message: any,
+    priority: 'high' | 'normal' = 'normal',
+    messageId?: string
+  ): Promise<boolean> => {
+    if (!userIds || userIds.length === 0) return false
+    const results = await Promise.all(
+      userIds.map((id) => sendMessage(id, message, priority, messageId))
+    )
+    return results.every(Boolean)
+  }
+
   // 发送广播消息
   const sendBroadcast = (type: string, data?: any) => {
     try {
@@ -622,6 +642,7 @@ export const useWebSocketMessage = () => {
   return {
     send,
     sendMessage,
+    sendToUsers,
     sendBroadcast,
     onMessage,
     onBroadcast,

--- a/src/views/bpm/processInstance/detail/index.vue
+++ b/src/views/bpm/processInstance/detail/index.vue
@@ -73,6 +73,7 @@
                 :process-users="processUsers"
                 :key="props.id"
                 :confirmed-online-users="confirmedOnlineUsers"
+                :editing-users="editingUsers"
                 ref="collaborationPanelRef"
               />
             </div>
@@ -344,9 +345,17 @@ const isAdmin = ref(false) // 是否为管理员
 // 在线用户检测
 const userStore = useUserStore()
 const currentUser = userStore.getUser
-const { processUsers, confirmedOnlineUsers, initCollaboration } = useFormCollaboration({
+const {
+  processUsers,
+  confirmedOnlineUsers,
+  initCollaboration,
+  broadcastFieldChange,
+  editingUsers,
+  isApplyingRemoteChange
+} = useFormCollaboration({
   processInstanceId: props.id,
-  currentUser
+  currentUser,
+  formApi: fApi
 })
 
 // 协作面板引用
@@ -1209,10 +1218,22 @@ const isHtmlContent = (content: string) => {
  */
 const onFormMounted = () => {
   console.log('表单挂载完成，初始化协同编辑功能')
-  
+
   // 初始化在线检测
   if (processDefinition.value?.formType === BpmModelFormType.NORMAL) {
     initCollaboration()
+    watch(
+      () => detailForm.value.value,
+      (newVal, oldVal) => {
+        if (!oldVal || isApplyingRemoteChange.value) return
+        for (const key in newVal) {
+          if (newVal[key] !== oldVal[key]) {
+            broadcastFieldChange(key, newVal[key])
+          }
+        }
+      },
+      { deep: true }
+    )
   }
 }
 


### PR DESCRIPTION
## Summary
- add helper to send WebSocket messages to multiple users
- support collaborative form editing with field change sync and editing status
- show editing state in FormCollaborationPanel

## Testing
- `pnpm lint:eslint` *(fails: ESLint couldn't find an eslint.config.js file)*

------
https://chatgpt.com/codex/tasks/task_b_6899e9314cb4832ba657b149d734f976