### PR TITLE
feat: sync form changes across collaborators

### DIFF
--- a/src/components/bpm/FormCollaborationPanel.vue
+++ b/src/components/bpm/FormCollaborationPanel.vue
@@ -29,7 +29,12 @@
     <!-- 用户列表 -->
     <div class="user-list-container" v-show="!isCollapsed">
       <transition-group name="user-list" tag="ul" class="user-list" v-if="onlineUsers.length">
-        <li v-for="user in onlineUsers" :key="user.id" class="user-item" :class="{'highlighted': user.id % 2 === 0}">
+        <li
+          v-for="user in onlineUsers"
+          :key="user.id"
+          class="user-item"
+          :class="{ highlighted: user.id % 2 === 0 }"
+        >
           <div class="user-avatar">
             <el-avatar :size="36" v-if="user.avatar" :src="user.avatar" />
             <el-avatar :size="36" v-else>{{ user.nickname?.substring(0, 1) }}</el-avatar>
@@ -38,7 +43,9 @@
           <div class="user-info">
             <span class="user-name">{{ user.nickname }}</span>
           </div>
-          <div class="user-status">在线</div>
+          <div class="user-status">
+            {{ props.editingUsers.has(user.id) ? '编辑中' : '在线' }}
+          </div>
         </li>
       </transition-group>
       <div v-else class="empty-state">
@@ -56,6 +63,7 @@ import { Close, Connection, UserFilled, ArrowUp, ArrowDown } from '@element-plus
 interface Props {
   processUsers: any[]
   confirmedOnlineUsers: Set<number>
+  editingUsers: Set<number>
 }
 
 const props = defineProps<Props>()

--- a/src/hooks/web/useFormCollaboration.ts
+++ b/src/hooks/web/useFormCollaboration.ts
@@ -1,10 +1,11 @@
-import { ref, computed, onUnmounted } from 'vue'
+import { ref, computed, onUnmounted, Ref } from 'vue'
 import * as TaskApi from '@/api/bpm/task'
 import { useWebSocketMessage, FormCollaborationMessageType } from './useWebSocketMessage'
 
 interface Config {
   processInstanceId: string
   currentUser: { id: number }
+  formApi?: Ref<any>
 }
 
 interface OnlineCheckPayload {
@@ -13,10 +14,21 @@ interface OnlineCheckPayload {
 }
 
 export const useFormCollaboration = (config: Config) => {
-  const { processInstanceId, currentUser } = config
+  const { processInstanceId, currentUser, formApi } = config
 
   const processUsers = ref<any[]>([])
   const confirmedOnlineUsers = ref<Set<number>>(new Set())
+
+  // 正在编辑的用户列表
+  const editingUsers = ref<Set<number>>(new Set())
+
+  // 标记是否正在应用远程变更，避免死循环
+  const isApplyingRemoteChange = ref(false)
+
+  // 协同编辑临时禁用字段的恢复定时器
+  const fieldRestoreTimers = new Map<string, NodeJS.Timeout>()
+  // 记录字段原始的禁用状态，避免恢复时覆盖原有权限
+  const fieldOriginalDisabled = new Map<string, boolean>()
 
   const chainStarted = ref(false)
   const chainInitiatorId = ref<number | null>(null)
@@ -24,7 +36,7 @@ export const useFormCollaboration = (config: Config) => {
   let responseTimer: NodeJS.Timeout | null = null
   let startTimer: NodeJS.Timeout | null = null
 
-  const { sendMessage, onMessage } = useWebSocketMessage()
+  const { sendMessage, onMessage, sendToUsers } = useWebSocketMessage()
 
   const sortedUserIds = computed(() =>
     processUsers.value.map((u: any) => u.id).sort((a: number, b: number) => a - b)
@@ -122,6 +134,29 @@ export const useFormCollaboration = (config: Config) => {
     }
   }
 
+  /**
+   * 广播表单字段变更
+   */
+  const broadcastFieldChange = (field: string, value: any) => {
+    // 标记当前用户正在编辑
+    editingUsers.value.add(currentUser.id)
+    setTimeout(() => editingUsers.value.delete(currentUser.id), 3000)
+
+    const targets = Array.from(confirmedOnlineUsers.value).filter(
+      (id) => id !== currentUser.id
+    )
+    if (targets.length === 0) return
+    sendToUsers(
+      targets,
+      {
+        type: FormCollaborationMessageType.FORM_FIELD_CHANGE,
+        data: { field, value }
+      },
+      'high',
+      processInstanceId
+    )
+  }
+
   const initCollaboration = async () => {
     await getProcessUsers()
     scheduleStart()
@@ -174,6 +209,45 @@ export const useFormCollaboration = (config: Config) => {
         if (responseTimer) clearTimeout(responseTimer)
         pendingResponseUserId.value = null
       }
+    } else if (msg.type === FormCollaborationMessageType.FORM_FIELD_CHANGE) {
+      const { field, value } = msg.data || {}
+      // 如果是自己发送的变更，直接忽略
+      if (!field || msg.fromUserId === currentUser.id) return
+
+      editingUsers.value.add(msg.fromUserId)
+      setTimeout(() => editingUsers.value.delete(msg.fromUserId), 3000)
+
+      if (formApi?.value) {
+        isApplyingRemoteChange.value = true
+        formApi.value.setValue(field, value)
+
+        // 记录原始禁用状态并暂时禁用字段
+        if (!fieldOriginalDisabled.has(field)) {
+          try {
+            const rule = formApi.value.getRule ? formApi.value.getRule(field) : null
+            fieldOriginalDisabled.set(field, rule?.props?.disabled ?? false)
+          } catch (e) {
+            fieldOriginalDisabled.set(field, false)
+          }
+        }
+        formApi.value.disabled(true, field)
+
+        // 若已有定时器则重置
+        if (fieldRestoreTimers.has(field)) {
+          clearTimeout(fieldRestoreTimers.get(field)!)
+        }
+        fieldRestoreTimers.set(
+          field,
+          setTimeout(() => {
+            const original = fieldOriginalDisabled.get(field) ?? false
+            formApi.value.disabled(original, field)
+            fieldRestoreTimers.delete(field)
+            fieldOriginalDisabled.delete(field)
+          }, 2000)
+        )
+
+        isApplyingRemoteChange.value = false
+      }
     }
   })
 
@@ -186,6 +260,9 @@ export const useFormCollaboration = (config: Config) => {
   return {
     processUsers,
     confirmedOnlineUsers,
-    initCollaboration
+    initCollaboration,
+    broadcastFieldChange,
+    editingUsers,
+    isApplyingRemoteChange
   }
 }

--- a/src/hooks/web/useWebSocketMessage.ts
+++ b/src/hooks/web/useWebSocketMessage.ts
@@ -410,6 +410,26 @@ export const useWebSocketMessage = () => {
     }
   }
 
+  /**
+   * 向多个用户发送消息
+   * @param userIds 目标用户ID数组
+   * @param message 消息内容
+   * @param priority 消息优先级
+   * @param messageId 自定义消息ID
+   */
+  const sendToUsers = async (
+    userIds: number[],
+    message: any,
+    priority: 'high' | 'normal' = 'normal',
+    messageId?: string
+  ): Promise<boolean> => {
+    if (!userIds || userIds.length === 0) return false
+    const results = await Promise.all(
+      userIds.map((id) => sendMessage(id, message, priority, messageId))
+    )
+    return results.every(Boolean)
+  }
+
   // 发送广播消息
   const sendBroadcast = (type: string, data?: any) => {
     try {
@@ -622,6 +642,7 @@ export const useWebSocketMessage = () => {
   return {
     send,
     sendMessage,
+    sendToUsers,
     sendBroadcast,
     onMessage,
     onBroadcast,

--- a/src/views/bpm/processInstance/detail/index.vue
+++ b/src/views/bpm/processInstance/detail/index.vue
@@ -73,6 +73,7 @@
                 :process-users="processUsers"
                 :key="props.id"
                 :confirmed-online-users="confirmedOnlineUsers"
+                :editing-users="editingUsers"
                 ref="collaborationPanelRef"
               />
             </div>
@@ -344,9 +345,17 @@ const isAdmin = ref(false) // 是否为管理员
 // 在线用户检测
 const userStore = useUserStore()
 const currentUser = userStore.getUser
-const { processUsers, confirmedOnlineUsers, initCollaboration } = useFormCollaboration({
+const {
+  processUsers,
+  confirmedOnlineUsers,
+  initCollaboration,
+  broadcastFieldChange,
+  editingUsers,
+  isApplyingRemoteChange
+} = useFormCollaboration({
   processInstanceId: props.id,
-  currentUser
+  currentUser,
+  formApi: fApi
 })
 
 // 协作面板引用
@@ -1209,10 +1218,22 @@ const isHtmlContent = (content: string) => {
  */
 const onFormMounted = () => {
   console.log('表单挂载完成，初始化协同编辑功能')
-  
+
   // 初始化在线检测
   if (processDefinition.value?.formType === BpmModelFormType.NORMAL) {
     initCollaboration()
+    watch(
+      () => detailForm.value.value,
+      (newVal, oldVal) => {
+        if (!oldVal || isApplyingRemoteChange.value) return
+        for (const key in newVal) {
+          if (newVal[key] !== oldVal[key]) {
+            broadcastFieldChange(key, newVal[key])
+          }
+        }
+      },
+      { deep: true }
+    )
   }
 }
 


### PR DESCRIPTION
## Summary
- add helper to send WebSocket messages to multiple users
- support collaborative form editing with field change sync and editing status
- show editing state in FormCollaborationPanel
- temporarily lock remote fields and restore their original state after edits

## Testing
- `pnpm lint:eslint` *(fails: ESLint couldn't find an eslint.config.js file)*

------
https://chatgpt.com/codex/tasks/task_b_6899e9314cb4832ba657b149d734f976