### PR TITLE
fix: handle missing sequence flow refs

### DIFF
--- a/src/components/bpmnProcessDesigner/package/designer/ProcessViewer.vue
+++ b/src/components/bpmnProcessDesigner/package/designer/ProcessViewer.vue
@@ -249,67 +249,53 @@ const onSelectElement = (element: any) => {
   }
 }
 
-/** 修复 SequenceFlow 中缺少 targetRef 的问题 */
-const fixSequenceFlowTargetRefs = (xml: string): string => {
+/** 修复 SequenceFlow 中缺少 sourceRef 或 targetRef 的问题 */
+const fixSequenceFlowRefs = (xml: string): string => {
   // 如果XML为空，直接返回
-  if (!xml) return xml;
-  
+  if (!xml) return xml
+
   try {
-    // 查找所有缺少 targetRef 的 SequenceFlow 标签
-    const regex = /<bpmn:SequenceFlow\s+id="([^"]+)"(?![^>]*targetRef=)[^>]*\/?>/g;
-    
-    // 计算找到的问题连线数量
-    const matches = xml.match(regex);
-    const matchCount = matches ? matches.length : 0;
-    
-    if (matchCount > 0) {
-      console.warn(`[BPM流程图] 发现 ${matchCount} 个缺少 targetRef 的 SequenceFlow 元素，已自动移除`);
-      
-      // 记录处理的元素ID
-      if (matches) {
-        matches.forEach(match => {
-          const idMatch = /<bpmn:SequenceFlow\s+id="([^"]+)"/.exec(match);
-          if (idMatch && idMatch[1]) {
-            console.info(`[BPM流程图] 移除无效连线: ID=${idMatch[1]}`);
-          }
-        });
+    const parser = new DOMParser()
+    const doc = parser.parseFromString(xml, 'application/xml')
+
+    const invalidIds: string[] = []
+    // 查找所有 SequenceFlow 标签
+    const sequenceFlows = Array.from(doc.getElementsByTagName('bpmn:SequenceFlow'))
+    sequenceFlows.forEach((flow) => {
+      const id = flow.getAttribute('id') || ''
+      const hasSource = flow.hasAttribute('sourceRef')
+      const hasTarget = flow.hasAttribute('targetRef')
+      if (!hasSource || !hasTarget) {
+        invalidIds.push(id)
+        flow.parentNode?.removeChild(flow)
       }
-      
-      // 从XML中移除这些问题的连线
-      // 策略1: 移除整个 SequenceFlow 标签
-      let fixedXml = xml.replace(regex, '<!-- 已移除缺少targetRef的SequenceFlow $1 -->');
-      
-      // 策略2: 同时尝试移除相关的 BPMNEdge 元素 (DI部分的可视化)
-      matches?.forEach(match => {
-        const idMatch = /<bpmn:SequenceFlow\s+id="([^"]+)"/.exec(match);
-        if (idMatch && idMatch[1]) {
-          const sequenceFlowId = idMatch[1];
-          const bpmnEdgeRegex = new RegExp(`<bpmndi:BPMNEdge[^>]*bpmnElement="${sequenceFlowId}"[^>]*>([\\s\\S]*?)<\\/bpmndi:BPMNEdge>`, 'g');
-          const beforeEdgeCount = (fixedXml.match(bpmnEdgeRegex) || []).length;
-          fixedXml = fixedXml.replace(bpmnEdgeRegex, `<!-- 已移除相关的 BPMNEdge for ${sequenceFlowId} -->`);
-          const afterEdgeCount = (fixedXml.match(bpmnEdgeRegex) || []).length;
-          
-          // 记录移除的边缘元素数量
-          if (beforeEdgeCount > afterEdgeCount) {
-            console.info(`[BPM流程图] 移除相关的图形元素: ID=${sequenceFlowId}, 数量=${beforeEdgeCount - afterEdgeCount}`);
-          }
+    })
+
+    if (invalidIds.length > 0) {
+      console.warn(`[BPM流程图] 发现 ${invalidIds.length} 个缺少 sourceRef 或 targetRef 的 SequenceFlow 元素，已自动移除`)
+
+      // 同时尝试移除相关的 BPMNEdge 元素 (DI部分的可视化)
+      const edges = Array.from(doc.getElementsByTagName('bpmndi:BPMNEdge'))
+      edges.forEach((edge) => {
+        const ref = edge.getAttribute('bpmnElement') || ''
+        if (invalidIds.includes(ref)) {
+          edge.parentNode?.removeChild(edge)
         }
-      });
-      
-      console.info('[BPM流程图] XML修复完成，已移除所有无效连线');
-      return fixedXml;
+      })
+
+      console.info('[BPM流程图] XML修复完成，已移除所有无效连线')
     }
-    
-    return xml;
+
+    return new XMLSerializer().serializeToString(doc)
   } catch (error) {
-    console.error('[BPM流程图] 修复XML时出错:', error);
+    console.error('[BPM流程图] 修复XML时出错:', error)
     // 提供详细的错误信息
     if (error instanceof Error) {
-      console.error('[BPM流程图] 错误详情:', error.message);
-      console.error('[BPM流程图] 错误堆栈:', error.stack);
+      console.error('[BPM流程图] 错误详情:', error.message)
+      console.error('[BPM流程图] 错误堆栈:', error.stack)
     }
-    
-    return xml; // 如果处理过程中出错，返回原始XML
+
+    return xml // 如果处理过程中出错，返回原始XML
   }
 }
 
@@ -322,7 +308,7 @@ const importXML = async (xml: string) => {
   if (xml != null && xml !== '') {
     try {
       // 在导入前修复XML中的问题
-      const fixedXml = fixSequenceFlowTargetRefs(xml);
+      const fixedXml = fixSequenceFlowRefs(xml);
       
       bpmnViewer.value = new BpmnViewer({
         additionalModules: [MoveCanvasModule],
@@ -343,9 +329,12 @@ const importXML = async (xml: string) => {
       // 尝试显示错误信息
       clearViewer()
       
-      // 如果错误是关于SequenceFlow的targetRef问题，提供更详细的错误信息
-      if (e.toString().includes('targetRef not specified')) {
-        console.warn('[BPM流程图] 检测到SequenceFlow缺少targetRef，尝试移除问题元素后重新导入');
+      // 如果错误是关于 SequenceFlow 的 sourceRef/targetRef 问题，提供更详细的错误信息
+      if (
+        e.toString().includes('targetRef not specified') ||
+        e.toString().includes('sourceRef not specified')
+      ) {
+        console.warn('[BPM流程图] 检测到SequenceFlow缺少 sourceRef 或 targetRef，尝试移除问题元素后重新导入');
         
         try {
           // 移除所有的SequenceFlow，进行一次兜底尝试

--- a/src/views/bpm/processInstance/detail/index.vue
+++ b/src/views/bpm/processInstance/detail/index.vue
@@ -607,7 +607,8 @@ const getProcessModelView = async () => {
   }
   // 请求BPMN模型视图数据 
   // 注：如果出现"failed to import <bpmn:SequenceFlow /> Error: targetRef not specified"错误
-  // 已在ProcessViewer组件中添加自动修复处理，会自动移除无效的连线并继续显示流程图
+  // 或者"sourceRef not specified"错误
+  // 已在 ProcessViewer 组件中添加自动修复处理，会自动移除无效的连线并继续显示流程图
   console.log('请求流程实例 BPMN 模型视图，ID:', props.id)
   const data = await ProcessInstanceApi.getProcessInstanceBpmnModelView(props.id)
   if (data) {


### PR DESCRIPTION
## Summary
- strip out SequenceFlow elements missing source or target refs before viewer import
- document automatic SequenceFlow cleanup during BPMN model load
- ensure XML cleanup uses DOMParser to remove full elements and related BPMNEdge entries without corrupting diagram XML

## Testing
- `pnpm lint:eslint` *(fails: ESLint couldn't find an eslint.config.js)*
- `pnpm run test` *(fails: Missing script: test)*

------
https://chatgpt.com/codex/tasks/task_b_689aa7ba5a00832e973509a64b14d087